### PR TITLE
Suppress compiler unused variable warning

### DIFF
--- a/sha256_literal.h
+++ b/sha256_literal.h
@@ -156,7 +156,7 @@ u8_to_blocks_(Ar const Data)
 
 template <uint64_t BlockCount, typename Ar>
 constexpr std::enable_if_t<BlockCount == 0, std::array<BlockType, 0>>
-u8_to_blocks_(Ar const Data)
+u8_to_blocks_(Ar const __attribute__((unused)) Data)
 {
   return std::array<BlockType, 0>{};
 }


### PR DESCRIPTION
The title says it all, GCC creates a rather nasty looking warning for the `Data` variable, this suppresses it.