### PR TITLE
Fix for always_inline and make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,4 @@ sha256.o: sha256.cpp
 tests.o: tests.cpp
 
 clean:
-	rm tests.o example
+	rm -f tests.o sha256.o example

--- a/sha256.cpp
+++ b/sha256.cpp
@@ -9,7 +9,7 @@
 #if defined(_MSC_VER)
 #define FORCEINLINE __forceinline
 #else
-#define FORCEINLINE __attribute__((always_inline))
+#define FORCEINLINE inline __attribute__((always_inline))
 #endif
 
 static const uint32_t SHA256_K[64] = {


### PR DESCRIPTION
1. Function marked as always_inline should be marked as `inline` too
2. Complete clean on `make clean` call
3. Do not fail `make clean` if no failed present, just exit silently